### PR TITLE
Initial cut at a CircleCI 2.0 config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     # Variable expansion in working_directory not supported at this time
     # You will need to modify the code below to reflect your github account/repo setup
-    working_directory: /go/src/github.com/<USERNAMEHERE>/<REPONAMEHERE>
+    working_directory: /go/src/github.com/eeble/invoicer-chapter3
     docker:
       - image: circleci/golang:1.8
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,66 @@
+version: 2
+jobs:
+  build:
+    # Variable expansion in working_directory not supported at this time
+    # You will need to modify the code below to reflect your github account/repo setup
+    working_directory: /go/src/github.com/<USERNAMEHERE>/<REPONAMEHERE>
+    docker:
+      - image: circleci/golang:1.8
+    environment:
+      GO15VENDOREXPERIMENT: 1
+    branches:
+      only:
+        - master
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run: echo 'export GOPATH_HEAD="$(echo ${GOPATH}|cut -d ':' -f 1)"' >> $BASH_ENV
+      - run: echo 'export GOPATH_BASE="${GOPATH_HEAD}/src/github.com/${CIRCLE_PROJECT_USERNAME}"' >> $BASH_ENV
+      - run: echo 'DOCKER_REPO="$(if [ ${CIRCLE_PROJECT_USERNAME} == 'Securing-DevOps' ]; then echo securingdevops; else echo $DOCKER_USER; fi)"' >> $BASH_ENV
+      - run: mkdir -p "${GOPATH_BASE}"
+      - run: mkdir -p "${GOPATH_HEAD}/bin"
+      - run: go get github.com/govend/govend
+      #- run: ln -fs "${HOME}/${CIRCLE_PROJECT_REPONAME}" "${GOPATH_BASE}/"
+          
+          
+          
+      - run:
+          name: GO test application
+          command: go test github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME};
+
+      - run:
+          name: Prepare application for OWASP ZAP testing
+          command: |
+            go install --ldflags '-extldflags "-static"' github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME};
+            [ ! -e bin ] && mkdir bin;
+            cp "${GOPATH_HEAD}/bin/${CIRCLE_PROJECT_REPONAME}" bin/invoicer;
+            docker build -t ${DOCKER_REPO}/${CIRCLE_PROJECT_REPONAME} .;
+      - run:
+          name: Run application in background
+          command: |
+            docker run ${DOCKER_REPO}/${CIRCLE_PROJECT_REPONAME}
+          background: true
+
+      - run:
+          name: OWASP ZAP testing of application
+          command: |
+            docker run -t owasp/zap2docker-weekly zap-baseline.py -u https://raw.githubusercontent.com/Securing-DevOps/invoicer/master/zap-baseline.conf -t http://172.17.0.2:8080/
+
+      - run:
+          name: Run govend
+          command: 'GOPATH="${GOPATH_HEAD}"; ( cd ${GOPATH_BASE}/${CIRCLE_PROJECT_REPONAME} && govend -u && git diff --quiet )'
+
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS};
+            echo ${DOCKER_USER}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG};
+            go install --ldflags '-extldflags "-static"' github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME};
+            mkdir bin;
+            cp "$GOPATH_HEAD/bin/${CIRCLE_PROJECT_REPONAME}" bin/invoicer;
+            docker build -t ${DOCKER_REPO}/${CIRCLE_PROJECT_REPONAME} .;
+            docker images --no-trunc | awk '/^app/ {print $3}' | sudo tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt;
+            docker push ${DOCKER_REPO}/${CIRCLE_PROJECT_REPONAME};
+            fi
+            

--- a/app-version.json
+++ b/app-version.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "docker.io/securingdevops/invoicer-chapter2",
+    "Name": "docker.io/securingdevops/invoicer-chapter3",
     "Update": "true"
   },
   "Ports": [


### PR DESCRIPTION
Unfortunately it requires that the working_directory be hard-coded. I am currently working on a fix for this.

All of the ENVVARs were added to the $BASH_ENV file which is sourced before each of the steps:
https://discuss.circleci.com/t/how-to-set-env-vars-for-local-builds-using-circleci-2-0/12714

Other than that I followed the migration guide and 2.0 documentation here:
https://circleci.com/docs/2.0/migrating-from-1-2/
https://circleci.com/docs/2.0/language-go/#config-walkthrough

I have also broken out the OWASP testing into separate commands to make it look nicer in CircleCI